### PR TITLE
fix: nav button show be visible fully on Safari

### DIFF
--- a/dev/serve.vue
+++ b/dev/serve.vue
@@ -52,6 +52,12 @@ a:hover > * {
   padding: 64px;
 }
 
+@media (max-width: 420px) {
+  #app {
+    padding: 24px;
+  }
+}
+
 @media (min-width: 1200px) {
   #app {
     padding-left: 80px;

--- a/package-lock.json
+++ b/package-lock.json
@@ -5373,9 +5373,9 @@
       "dev": true
     },
     "cypress": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-6.1.0.tgz",
-      "integrity": "sha512-uQnSxRcZ6hkf9R5cr8KpRBTzN88QZwLIImbf5DWa5RIxH6o5Gpff58EcjiYhAR8/8p9SGv7O6SRygq4H+k0Qpw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-6.2.0.tgz",
+      "integrity": "sha512-m/rkcogYM9MTy8rbsZgyS5wT2L/J+B5V2bY2ztkDNMyqhk/oZgUF4KTWVLzkW2I+scg0iAddca95tLlt7XnAtw==",
       "dev": true,
       "requires": {
         "@cypress/listr-verbose-renderer": "^0.4.1",
@@ -7748,12 +7748,20 @@
       "dev": true
     },
     "global-dirs": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-2.0.1.tgz",
-      "integrity": "sha512-5HqUqdhkEovj2Of/ms3IeS/EekcO54ytHRLV4PEY2rhRwrHXLQjeVEES0Lhka0xwNDtGYn58wyC4s5+MHsOO6A==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-2.1.0.tgz",
+      "integrity": "sha512-MG6kdOUh/xBnyo9cJFeIKkLEc1AyFq42QTU4XiX51i2NEdxLxLWXIjEjmqKeSuKR7pAZjTqUVoT2b2huxVLgYQ==",
       "dev": true,
       "requires": {
-        "ini": "^1.3.5"
+        "ini": "1.3.7"
+      },
+      "dependencies": {
+        "ini": {
+          "version": "1.3.7",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.7.tgz",
+          "integrity": "sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==",
+          "dev": true
+        }
       }
     },
     "global-modules": {
@@ -11890,9 +11898,9 @@
       "optional": true
     },
     "pretty-bytes": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.4.1.tgz",
-      "integrity": "sha512-s1Iam6Gwz3JI5Hweaz4GoCD1WUNUIyzePFy5+Js2hjwGVt2Z79wNN+ZKOZ2vB6C+Xs6njyB84Z1IthQg8d9LxA==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.5.0.tgz",
+      "integrity": "sha512-p+T744ZyjjiaFlMUZZv6YPC5JrkNj8maRmPaQCWFJFplUAzpIUTRaTcS+7wmZtUoFXHtESJb23ISliaWyz3SHA==",
       "dev": true
     },
     "pretty-error": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@vue/eslint-config-typescript": "^7.0.0",
     "babel-plugin-transform-remove-console": "^6.9.4",
     "cross-env": "^7.0.2",
-    "cypress": "^6.1.0",
+    "cypress": "^6.2.0",
     "cypress-image-snapshot": "^4.0.0",
     "eslint": "^7.15.0",
     "eslint-plugin-vue": "^7.2.0",

--- a/src/vue-horizontal.vue
+++ b/src/vue-horizontal.vue
@@ -2,17 +2,21 @@
   <div class="vue-horizontal">
     <div class="v-hl-btn v-hl-btn-prev" v-if="button && hasPrev" @click="prev">
       <slot name="btn-prev">
-        <svg viewBox="0 0 24 24">
-          <path d="m9.8 12 5 5a1 1 0 1 1-1.4 1.4l-5.7-5.7a1 1 0 0 1 0-1.4l5.7-5.7a1 1 0 0 1 1.4 1.4l-5 5z"/>
-        </svg>
+        <div>
+          <svg viewBox="0 0 24 24">
+            <path d="m9.8 12 5 5a1 1 0 1 1-1.4 1.4l-5.7-5.7a1 1 0 0 1 0-1.4l5.7-5.7a1 1 0 0 1 1.4 1.4l-5 5z"/>
+          </svg>
+        </div>
       </slot>
     </div>
 
     <div class="v-hl-btn v-hl-btn-next" v-if="button && hasNext" @click="next">
       <slot name="btn-next">
-        <svg viewBox="0 0 24 24">
-          <path d="m14.3 12.1-5-5a1 1 0 0 1 1.4-1.4l5.7 5.7a1 1 0 0 1 0 1.4l-5.7 5.7a1 1 0 0 1-1.4-1.4l5-5z"/>
-        </svg>
+        <div>
+          <svg viewBox="0 0 24 24">
+            <path d="m14.3 12.1-5-5a1 1 0 0 1 1.4-1.4l5.7 5.7a1 1 0 0 1 0 1.4l-5.7 5.7a1 1 0 0 1-1.4-1.4l5-5z"/>
+          </svg>
+        </div>
       </slot>
     </div>
 
@@ -183,29 +187,38 @@ export default Vue.extend({
 .v-hl-btn {
   position: absolute;
   align-self: center;
+  line-height: 0;
+}
+
+.v-hl-btn:hover {
+  cursor: pointer;
 }
 
 .v-hl-btn-prev {
-  left: -24px;
+  left: 0;
 }
 
 .v-hl-btn-next {
-  right: -24px;
+  right: 0;
+}
+
+.v-hl-btn-prev > div {
+  margin-left: -26px;
+}
+
+.v-hl-btn-next > div {
+  margin-right: -26px;
 }
 
 svg {
-  width: 42px;
-  height: 42px;
-  margin: 0;
+  width: 40px;
+  height: 40px;
+  margin: 6px;
   padding: 6px;
   border-radius: 21px;
   box-sizing: border-box;
   background: white;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
-}
-
-svg:hover {
-  cursor: pointer;
 }
 
 .v-hl-container {

--- a/src/vue-horizontal.vue
+++ b/src/vue-horizontal.vue
@@ -188,6 +188,7 @@ export default Vue.extend({
   position: absolute;
   align-self: center;
   line-height: 0;
+  z-index: 1;
 }
 
 .v-hl-btn:hover {


### PR DESCRIPTION
Should be fully visible and not hidden behind the container, including the shadow. This also moves the nav button edge center alignment the user.

### Tested On
* Safari iOS
* Safari Desktop

### Expected
<img width="375px" src="https://user-images.githubusercontent.com/4266087/102972329-d4c20380-4535-11eb-9595-b18c9789cced.png">
