### PR TITLE
feat: refresh() for rendering update

### DIFF
--- a/cypress/integration/functional/append.spec.js
+++ b/cypress/integration/functional/append.spec.js
@@ -1,0 +1,79 @@
+/// <reference types="cypress" />
+
+describe('append', () => {
+  beforeEach(() => {
+    cy.viewport(1600, 1000)
+    cy.visit('http://localhost:8080/append')
+  })
+
+  it('should not exist before append', function () {
+    cy.get('.v-hl-container > :nth-child(2)')
+      .should('not.exist');
+
+    cy.get('.v-hl-btn-prev').should('not.exist');
+    cy.get('.v-hl-btn-next').should('not.exist');
+  });
+
+  it('should append 1', function () {
+    cy.get('.v-hl-container > :nth-child(2)')
+      .should('not.exist');
+    cy.get('.append-1').click();
+    cy.get('.v-hl-container > :nth-child(2)')
+      .should('exist');
+  });
+
+  it('should append 1 + 1', function () {
+    cy.get('.append-1').click();
+    cy.get('.append-1').click();
+    cy.get('.v-hl-container > :nth-child(3)')
+      .should('exist');
+  });
+
+  it('should append 100', function () {
+    cy.get('.append-100').click();
+    cy.get('.v-hl-container > :nth-child(101)')
+      .should('exist');
+  });
+
+  it('should not show nav button after append', function () {
+    cy.get('.append-1').click();
+
+    cy.get('.v-hl-container > :nth-child(2)').should('exist');
+    cy.get('.v-hl-btn-prev').should('not.exist');
+    cy.get('.v-hl-btn-next').should('not.exist');
+  });
+
+  it('should show nav button after append', function () {
+    cy.get('.append-1').click();
+    cy.get('.append-10').click();
+
+    cy.get('.v-hl-container > :nth-child(2)').should('exist');
+    cy.get('.v-hl-btn-prev').should('not.exist');
+    cy.get('.v-hl-btn-next').should('exist');
+  });
+
+  it('should show nav button after append twice', function () {
+    cy.get('.append-10').click();
+    cy.get('.v-hl-btn-next').click();
+    cy.wait(1500);
+    cy.get('.v-hl-btn-next').click();
+
+
+    cy.get('.v-hl-btn-prev').should('exist');
+    cy.get('.v-hl-btn-next').should('not.exist');
+
+    cy.get('.append-10').click();
+
+    cy.get('.v-hl-btn-prev').should('exist');
+    cy.get('.v-hl-btn-next').should('exist');
+  });
+
+  it('should show nav button when between', function () {
+    cy.get('.append-10').click();
+    cy.get('.v-hl-btn-next').click();
+    cy.get('.append-10').click();
+
+    cy.get('.v-hl-btn-prev').should('exist');
+    cy.get('.v-hl-btn-next').should('exist');
+  });
+})

--- a/dev/components/append.vue
+++ b/dev/components/append.vue
@@ -1,0 +1,98 @@
+<template>
+  <div>
+    <vue-horizontal responsive ref="horizontal">
+      <section v-for="item in items" :key="item.i">
+        <div class="header">
+          <h6>{{ item.i }}</h6>
+          <h3>{{ item.title }}</h3>
+        </div>
+        <p>{{ item.content }}</p>
+      </section>
+    </vue-horizontal>
+
+    <div>
+      <button @click="append(i)" v-for="i in [1,5,10,20,50,100,1000]" :key="i" :class="`append-${i}`">
+        Append {{ i }}
+      </button>
+    </div>
+
+    <div>
+      <button @click="goIndex(i)" v-for="i in [1,5,10,20,50,100,1000]" :key="i" :class="`go-${i}`">
+        Go {{ i }}
+      </button>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+import VueHorizontal from '@/vue-horizontal.vue';
+import {Lorem} from './utils'
+
+const lorem = Lorem("append")
+
+export default Vue.extend({
+  components: {
+    VueHorizontal
+  },
+  data() {
+    return {
+      items: [{
+        i: 0,
+        title: lorem.generateWords(1),
+        content: lorem.generateWords(4),
+      }],
+    }
+  },
+  methods: {
+    append(count: number) {
+      this.items.push(...[...Array(count).keys()].map((i) => {
+        return {
+          i: i + this.items.length,
+          title: lorem.generateWords(1),
+          content: lorem.generateWords(4),
+        };
+      }))
+
+      const horizontal = this.$refs.horizontal as any
+      this.$nextTick(() => {
+        horizontal.refresh()
+      })
+    },
+    goIndex(index: number) {
+      const horizontal = this.$refs.horizontal as any
+      horizontal.scrollToIndex(index)
+    }
+  }
+});
+</script>
+
+<style scoped>
+section {
+  padding: 16px 24px;
+  border-radius: 4px;
+  background: #f5f5f5;
+}
+
+.header {
+  display: flex;
+}
+
+.header h6 {
+  background: #0000db;
+  flex-shrink: 0;
+  font-size: 14px;
+  color: white;
+  width: 24px;
+  height: 24px;
+  text-align: center;
+  line-height: 24px;
+  border-radius: 12px;
+  margin-right: 12px;
+}
+
+button {
+  margin-top: 24px;
+  margin-right: 12px;
+}
+</style>

--- a/dev/components/event.vue
+++ b/dev/components/event.vue
@@ -1,10 +1,10 @@
 <template>
   <div>
     <vue-horizontal
-      @scroll="(data) => scroll = data"
-      @scroll-debounce="(data) => scrollDebounce = data"
-      @prev="() => prev = 'prev'"
-      @next="() => next = 'next'"
+        @scroll="(data) => scroll = data"
+        @scroll-debounce="(data) => scrollDebounce = data"
+        @prev="() => prev = 'prev'"
+        @next="() => next = 'next'"
     >
       <section v-for="item in items" :key="item.i">
         <div class="header">

--- a/dev/components/index.ts
+++ b/dev/components/index.ts
@@ -11,6 +11,7 @@ import Event from './event.vue';
 import Responsive from './responsive.vue';
 import Move from './move.vue';
 import ContentOverflow from './content-overflow.vue';
+import Append from './append.vue';
 
 export interface ComponentMeta {
   path: string;
@@ -97,6 +98,12 @@ const components: ComponentMeta[] = [
     name: 'content-overflow',
     description: 'Test content larger that 100vw.',
     component: ContentOverflow,
+  },
+  {
+    path: '/append',
+    name: 'append',
+    description: 'Dom manipulation',
+    component: Append,
   },
 ]
 

--- a/docs/content/en/features.md
+++ b/docs/content/en/features.md
@@ -136,6 +136,38 @@ Emitted when prev or next are clicked.
 ```vue[MethodScrollLeft.vue] import=features/features-method-scroll-left.vue
 ```
 
+### `refresh()`
+
+Update Vue Horizontal internal data required for rendering update after dom changes.
+
+Vue Horizontal uses slot that can encompass any HTML passed in without parsing,
+thus you need to tell Vue Horizontal when you updated the dom. 
+This is designed to prevent cyclical event loop that causes browser to hang.
+
+```vue
+<template>
+  <vue-horizontal ref="horizontal">
+    <div v-for="i in items"></div>
+  </vue-horizontal>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      items: [0,1,2,3]
+    }
+  },
+  methods: {
+    update() {
+      this.items.push(4,5,6,7,8)
+      this.$refs.horizontal.refresh()
+    }
+  }
+}
+</script>
+```
+
 ## Displacement
 
 Displacement is a positive float number that you can override for a custom scroll displacement. Defaults to `1.0`.

--- a/src/vue-horizontal.vue
+++ b/src/vue-horizontal.vue
@@ -190,6 +190,17 @@ export default Vue.extend({
       this.debounceId = window.setTimeout(this.onScrollDebounce, 500);
     },
     onScrollDebounce(): void {
+      this.refresh();
+
+      this.$emit('scroll-debounce', {
+        left: this.left,
+        containerWidth: this.containerWidth,
+        scrollWidth: this.scrollWidth,
+        hasPrev: this.hasPrev,
+        hasNext: this.hasNext,
+      })
+    },
+    refresh(): void {
       const container = this.$refs.container as Element
       const slot0 = this.$slots?.default?.find(s => s.tag)?.elm as Element
 
@@ -212,15 +223,7 @@ export default Vue.extend({
       this.scrollWidth = container.scrollWidth
       this.hasNext = hasNext()
       this.hasPrev = hasPrev()
-
-      this.$emit('scroll-debounce', {
-        left: this.left,
-        containerWidth: this.containerWidth,
-        scrollWidth: this.scrollWidth,
-        hasPrev: this.hasPrev,
-        hasNext: this.hasNext,
-      })
-    },
+    }
   },
 });
 </script>


### PR DESCRIPTION
Update Vue Horizontal internal data required for rendering update after DOM changes.

Vue Horizontal uses slot that can encompass any HTML passed in without parsing, thus you need to tell Vue Horizontal when you updated the dom. This is designed to prevent cyclical event loop that causes browser to hang.