### PR TITLE
fix: merge and simplify redundant 'findSlot' func

### DIFF
--- a/src/vue-horizontal.vue
+++ b/src/vue-horizontal.vue
@@ -116,37 +116,8 @@ export default Vue.extend({
       const container = this.$refs.container as Element
       return container.children
     },
-    findPrevSlot(x: number): Element | undefined {
-      const children = this.children()
-
-      for (let i = 0; i < children.length; i++) {
-        const rect = children[i].getBoundingClientRect()
-
-        if (rect.left <= x && x <= rect.right) {
-          return children[i]
-        }
-
-        if (x <= rect.left) {
-          return children[i]
-        }
-      }
-    },
-    findNextSlot(x: number): Element | undefined {
-      const children = this.children()
-
-      for (let i = 0; i < children.length; i++) {
-        const rect = children[i].getBoundingClientRect()
-
-        if (rect.right <= x) {
-          continue;
-        } else if (rect.left <= x) {
-          return children[i];
-        }
-
-        if (x <= rect.left) {
-          return children[i];
-        }
-      }
+    findTargetSlot(targetPos: number): Element | undefined {
+      return [...this.children()].find((element) => targetPos <= element.getBoundingClientRect().right)
     },
     /**
      * Toggle and scroll to the previous set of horizontal content.
@@ -157,7 +128,7 @@ export default Vue.extend({
       const container = this.$refs.container as Element
       const left = container.getBoundingClientRect().left
       const x = left + (container.clientWidth * -this.displacement) - delta
-      const element = this.findPrevSlot(x)
+      const element = this.findTargetSlot(x)
 
       if (element) {
         const width = element.getBoundingClientRect().left - left
@@ -177,7 +148,7 @@ export default Vue.extend({
       const container = this.$refs.container as Element
       const left = container.getBoundingClientRect().left
       const x = left + (container.clientWidth * this.displacement) + delta
-      const element = this.findNextSlot(x)
+      const element = this.findTargetSlot(x)
 
       if (element) {
         const width = element.getBoundingClientRect().left - left


### PR DESCRIPTION
While working with this package I found that `findNextSlot` and `findPrevSlot` do exactly the same thing, with the logical operations written slightly differently. Both functions boil down to a single condition:

```
for (let i = 0; i < children.length; i++) {
  const rect = children[i].getBoundingClientRect()

  if ( x <= rect.right) return children[i]
  else continue
}
```

I combined these functions into one new function, and I also rewrote it using `Array.find` instead of a for loop to make it more concise.

This doesn't change any behavior of the package, just makes the code cleaner and easier to maintain. I hope this helps!