### PR TITLE
fix(ssr): prevent bug when $refs.container not found children

### DIFF
--- a/src/vue-horizontal.vue
+++ b/src/vue-horizontal.vue
@@ -114,7 +114,7 @@ export default Vue.extend({
   methods: {
     children(): HTMLCollection {
       const container = this.$refs.container as Element
-      return container.children
+      return container?.children ?? []
     },
     findPrevSlot(x: number): Element | undefined {
       const children = this.children()


### PR DESCRIPTION
It's for prevent bugs when components not found children.

I have this bug with nuxt + SSR

#105 